### PR TITLE
MVP workable tool

### DIFF
--- a/bin/dropsonde
+++ b/bin/dropsonde
@@ -12,10 +12,10 @@ class Dropsonde
   config_file '.config/dropsonde.rc'
 
   desc 'Verbose logging'
-  switch [:v, :verbose]
+  switch [:verbose, :v]
 
   desc 'Auto update the Forge module name cache if expired'
-  switch [:u, :update], :default_value => true
+  switch [:update], :default_value => true
 
   desc 'Path to cache directory'
   flag [:cachepath], :default_value => "#{Puppet.settings[:vardir]}/dropsonde"
@@ -23,7 +23,11 @@ class Dropsonde
   desc 'Forge module cache ttl in days'
   flag [:ttl], :default_value => 7, :type => Integer
 
+  desc 'List of metrics to omit'
+  flag [:blacklist, :b], :type => Array
+
   pre do |global, command, options, args|
+    Dropsonde.settings = global
     Dropsonde::Cache.init(global[:cachepath], global[:ttl], global[:update])
   end
 

--- a/dropsonde.gemspec
+++ b/dropsonde.gemspec
@@ -1,3 +1,5 @@
+require 'date'
+
 Gem::Specification.new do |s|
   s.name              = "dropsonde"
   s.version           = "0.0.1"
@@ -19,6 +21,8 @@ Gem::Specification.new do |s|
   s.add_dependency      "puppet"
   s.add_dependency      "puppet_forge"
   s.add_dependency      "semantic_puppet"
+  s.add_dependency      "inifile"
+  s.add_dependency      "puppetdb-ruby"
 
   s.description       = <<~desc
   Dropsonde is a simple telemetry probe designed to run as a regular cron job. It

--- a/lib/dropsonde.rb
+++ b/lib/dropsonde.rb
@@ -1,40 +1,57 @@
 require 'json'
 require 'httpclient'
+require 'puppetdb'
+require 'inifile'
 
 class Dropsonde
   require 'dropsonde/cache'
   require 'dropsonde/metrics'
+  require 'dropsonde/monkeypatches'
+
+  @@pdbclient = nil
+  @@settings  = {}
+  def self.settings=(arg)
+    raise "Requires a Hash to set all settings at once, not a #{arg.class}" unless arg.is_a? Hash
+    @@settings = arg
+  end
+
+  def self.settings
+    @@settings
+  end
 
   def self.generate_schema
     puts JSON.pretty_generate(Dropsonde::Metrics.new.schema)
   end
 
   def self.generate_report
+    puts
     puts Dropsonde::Metrics.new.preview
   end
 
   def self.submit_report(endpoint, port)
-    report = {
-      # I don't understand how this data structure relates to the published schemas
-      "product": "popularity-module",
-      "version": "1.0.0",
-      "self-service-analytics": {
-        "puppetserver.module-classes":{
-          "value":[],  # Dropsonde::Metrics.new.report ?
-          "timestamp":"2020-01-09T21:54:16.856Z"
-        }
-      }
-    }
-
     client = HTTPClient.new()
     result = client.post("#{endpoint}:#{port}",
                   :header => {'Content-Type' => 'application/json'},
-                  :body   => report.to_json
+                  :body   => Dropsonde::Metrics.new.report.to_json
                 )
+  end
 
-                require 'pry'
-                binding.pry
+  def self.puppetDB
+    return @@pdbclient if @@pdbclient
 
+    config = File.join(Puppet.settings[:confdir], 'puppetdb.conf')
+
+    return unless File.file? config
+
+    server = IniFile.load(config)['main']['server_urls'].split(',').first
+
+    @@pdbclient = PuppetDB::Client.new({
+    :server => server,
+    :pem    => {
+        'key'     => Puppet.settings[:hostprivkey],
+        'cert'    => Puppet.settings[:hostcert],
+        'ca_file' => Puppet.settings[:localcacert],
+    }})
   end
 
 end

--- a/lib/dropsonde/metrics/modules.rb
+++ b/lib/dropsonde/metrics/modules.rb
@@ -1,6 +1,6 @@
 class Dropsonde::Metrics::Modules
   def self.initialize_modules
-    # require any libraries needed here -- puppet is already initialized
+    # require any libraries needed here -- no need to load puppet; it's already initialized
   end
 
   def self.description
@@ -12,6 +12,7 @@ class Dropsonde::Metrics::Modules
 
   def self.schema
     # return an array of hashes of a partial schema to be merged into the complete schema
+    # See https://cloud.google.com/bigquery/docs/schemas#specifying_a_json_schema_file
     [
       {
         "fields": [
@@ -19,6 +20,12 @@ class Dropsonde::Metrics::Modules
             "description": "The module name",
             "mode": "NULLABLE",
             "name": "name",
+            "type": "STRING"
+          },
+          {
+            "description": "The module slug (author-name)",
+            "mode": "NULLABLE",
+            "name": "slug",
             "type": "STRING"
           },
           {
@@ -32,6 +39,26 @@ class Dropsonde::Metrics::Modules
         "mode": "REPEATED",
         "name": "modules",
         "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "description": "The class name",
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING"
+          },
+          {
+            "description": "How many nodes it is declared on",
+            "mode": "NULLABLE",
+            "name": "count",
+            "type": "INTEGER"
+          }
+        ],
+        "description": "List of classes and counts in all environments.",
+        "mode": "REPEATED",
+        "name": "classes",
+        "type": "RECORD"
       }
     ]
   end
@@ -41,23 +68,43 @@ class Dropsonde::Metrics::Modules
   end
 
   def self.run
-    # return a hash of data to be merged into the combined checkin
+    # return an array of hashes representing the data to be merged into the combined checkin
     environments = Puppet.lookup(:environments).list.map{|e|e.name}
     modules = environments.map do |env|
       Puppet.lookup(:environments).get(env).modules.map do|mod|
+        next unless mod.forge_module?
+
         {
-          :name    => mod.metadata['name'] || "#{mod.author}-#{mod.name}",
-          :version => mod.metadata['version']
+          :name    => mod.name,
+          :slug    => mod.forge_slug,
+          :version => mod.version,
         }
       end
-    end.flatten.uniq
+    end.flatten.compact.uniq
+
+    if Dropsonde.puppetDB
+      # classes and how many nodes they're enforced on
+      results = Dropsonde.puppetDB.request( '',
+        'resources[certname, type, title] { type = "Class" }'
+      ).data
+
+      # select only classes from public modules
+      classes = results.map do |klass|
+        next unless modules.find {|mod| mod[:name] == klass['title'].split('::').first.downcase }
+
+        {
+          :name  => klass['title'],
+          :count => results.select {|row| row['title'] == klass['title']}.count,
+        }
+      end.compact.uniq
+    else
+      classes = []
+    end
 
     [
-      {
-        :modules => modules.select {|mod| Dropsonde::Cache.modules.include? mod[:name] },
-      }
+      { :modules => modules },
+      { :classes => classes },
     ]
-
   end
 
   def self.cleanup

--- a/lib/dropsonde/monkeypatches.rb
+++ b/lib/dropsonde/monkeypatches.rb
@@ -1,0 +1,11 @@
+module Puppet
+  class Module
+    def forge_module?
+      Dropsonde::Cache.forgeModule? self
+    end
+
+    def forge_slug
+      self.forge_name.tr('/','-') rescue nil
+    end
+  end
+end


### PR DESCRIPTION
This is the barebones of what a minimally viable telemetry probe could
be. It now allows the user to blacklist metric groups, has a puppetDB
client, and generates reports and schema, and submits data. Of course,
the submission *will* fail until we get the dataset & schema created.