### PR TITLE
Load Ruby's CA certificates instead of using httpclient defaults

### DIFF
--- a/lib/dropsonde.rb
+++ b/lib/dropsonde.rb
@@ -52,6 +52,15 @@ class Dropsonde
 
   def self.submit_report(endpoint, port)
     client = HTTPClient.new
+
+    # The httpclient gem ships with some expired CA certificates.
+    # This causes us to load the certs shipped with whatever
+    # Ruby is used to execute this gem's commands, which are generally
+    # more up-to-date, especially if using puppet-agent's Ruby.
+    #
+    # Note that this is no-op with Windows system Ruby.
+    client.ssl_config.set_default_paths
+
     result = client.post("#{endpoint}:#{port}",
                          header: { 'Content-Type' => 'application/json' },
                          body: Dropsonde::Metrics.new.report.to_json)

--- a/spec/unit/dropsonde_spec.rb
+++ b/spec/unit/dropsonde_spec.rb
@@ -55,7 +55,10 @@ RSpec.describe Dropsonde do
   end
 
   context 'when submit report' do
-    let(:http_client) { double }
+    let(:http_client) {
+      double("client",
+             ssl_config: double("ssl_config", set_default_paths: "foo"))
+    }
     let(:report) { double }
     let(:report_tojson) { double }
     let(:telemetry_report) { JSON.parse('{ "foo": "bar" }') }


### PR DESCRIPTION
The `httpclient` gem uses a CA certificate bundle from 2015 (as of
version 2.8.3), see https://github.com/nahi/httpclient/issues/445. When
the Let's Encrypt root cert expired recently, this gem started failing
SSL handshakes, because the CA bundle it was using did not contain an
alternate trust path.

Calling `set_default_paths` on the client's SSL store causes it to load
the certs shipped with the Ruby runtime being used to execute dropsonde.
In most cases, these certs will be more up-to-date, and should allow the
connection to succeed. This is definitely true when running with
puppet-agent's Ruby.

With Windows system Ruby, this won't be sufficient. Recommended
workaround is to use puppet-agent's Ruby on Windows if possible.