### PR TITLE
(SERVER-3079) Allow overriding Puppet's base settings

### DIFF
--- a/lib/dropsonde.rb
+++ b/lib/dropsonde.rb
@@ -15,7 +15,32 @@ class Dropsonde
   require 'dropsonde/monkeypatches'
   require 'dropsonde/version'
 
-  Puppet.initialize_settings
+  def self.puppet_settings_overrides
+    overrides = []
+    if confdir = ENV['PUPPET_CONFDIR']
+      overrides << '--confdir'
+      overrides << confdir
+    end
+
+    if codedir = ENV['PUPPET_CODEDIR']
+      overrides << '--codedir'
+      overrides << codedir
+    end
+
+    if vardir = ENV['PUPPET_VARDIR']
+      overrides << '--vardir'
+      overrides << vardir
+    end
+
+    if logdir = ENV['PUPPET_LOGDIR']
+      overrides << '--logdir'
+      overrides << logdir
+    end
+
+    overrides
+  end
+
+  Puppet.initialize_settings(puppet_settings_overrides)
 
   @pdbclient = nil
   @settings  = {}


### PR DESCRIPTION
When Dropsonde is run from within Puppet Server, Puppet calculates its
default settings values for the non-root 'puppet' user. These paths are
incorrect and need to be overridden. Because we need to initialize
Puppet's settings before parsing commandline args, this commit adds
environment variables that can be set to override the relevant values.