### PR TITLE
Updates the telemetry endpoint to a stable URL

### DIFF
--- a/bin/dropsonde
+++ b/bin/dropsonde
@@ -69,7 +69,7 @@ class Dropsonde
   desc 'Submit a telemetry report'
   command :submit do |c|
     c.desc 'Telemetry endpoint'
-    c.flag [:endpoint], :default_value => 'https://prod.dujour.k8s.puppet.net'
+    c.flag [:endpoint], :default_value => 'https://updates.puppet.com'
 
     c.desc 'Telemetry port'
     c.flag [:port], :default_value => 443, :type => Integer


### PR DESCRIPTION
Updates the telemetry endpoint to updates.puppet.com; prod.dujour.k8s.puppet.net was not intended as a stable URL and will be removed at some point in the future.