### PR TITLE
Fix example generation

### DIFF
--- a/lib/dropsonde/cache.rb
+++ b/lib/dropsonde/cache.rb
@@ -7,11 +7,15 @@ require 'puppet_forge'
 
 # cache class
 class Dropsonde::Cache
+  @@cache = nil
   @autoupdate = false
 
-  def initialize(path, ttl, autoupdate)
+  def initialize(path='~/.dropsonde', ttl=7, autoupdate=true)
+    return if @@cache # make the class singleton
+
+    path = File.expand_path(path)
     FileUtils.mkdir_p(path)
-    @path = "#{File.expand_path(path)}/forge.json"
+    @path = "#{path}/forge.json"
     @ttl  = ttl
     @autoupdate = autoupdate
 

--- a/lib/dropsonde/cache.rb
+++ b/lib/dropsonde/cache.rb
@@ -11,8 +11,6 @@ class Dropsonde::Cache
   @autoupdate = false
 
   def initialize(path='~/.dropsonde', ttl=7, autoupdate=true)
-    return if @@cache # make the class singleton
-
     path = File.expand_path(path)
     FileUtils.mkdir_p(path)
     @path = "#{path}/forge.json"
@@ -31,8 +29,12 @@ class Dropsonde::Cache
     PuppetForge.user_agent = 'Dropsonde Telemetry Client/0.0.1'
   end
 
-  def modules
+  def self.modules
     @@cache['modules']
+  end
+
+  def modules
+    Dropsonde::Cache.modules
   end
 
   def cache

--- a/lib/dropsonde/metrics/dependencies.rb
+++ b/lib/dropsonde/metrics/dependencies.rb
@@ -71,7 +71,7 @@ class Dropsonde::Metrics::Dependencies
     # make it easier to write data aggregation queries without access to the
     # actual private data that users have submitted.
 
-    dropsonde_cache = Dropsonde::Cache.new('foo', 7, true)
+    dropsonde_cache = Dropsonde::Cache.new()
     versions = ['>= 1.5.2', '>= 4.3.2', '>= 3.0.0 < 4.0.0', '>= 2.2.1 < 5.0.0', '>= 5.0.0 < 7.0.0', '>= 4.11.0']
     [
       dependencies: dropsonde_cache.modules

--- a/lib/dropsonde/metrics/dependencies.rb
+++ b/lib/dropsonde/metrics/dependencies.rb
@@ -71,10 +71,9 @@ class Dropsonde::Metrics::Dependencies
     # make it easier to write data aggregation queries without access to the
     # actual private data that users have submitted.
 
-    dropsonde_cache = Dropsonde::Cache.new()
     versions = ['>= 1.5.2', '>= 4.3.2', '>= 3.0.0 < 4.0.0', '>= 2.2.1 < 5.0.0', '>= 5.0.0 < 7.0.0', '>= 4.11.0']
     [
-      dependencies: dropsonde_cache.modules
+      dependencies: Dropsonde::Cache.modules
                                    .sample(rand(250))
                                    .map do |item|
                       {

--- a/lib/dropsonde/metrics/modules.rb
+++ b/lib/dropsonde/metrics/modules.rb
@@ -119,7 +119,7 @@ class Dropsonde::Metrics::Modules
 
     versions = ['1.3.2', '0.0.1', '0.1.2', '1.0.0', '3.0.2', '7.10', '6.1.0', '2.1.0', '1.4.0']
     classes = ['', '::Config', '::Service', '::Server', '::Client', '::Packages']
-    dropsonde_cache = Dropsonde::Cache.new('foo', 7, true)
+    dropsonde_cache = Dropsonde::Cache.new()
     [
       modules: dropsonde_cache.modules
                               .sample(rand(100))

--- a/lib/dropsonde/metrics/modules.rb
+++ b/lib/dropsonde/metrics/modules.rb
@@ -119,9 +119,8 @@ class Dropsonde::Metrics::Modules
 
     versions = ['1.3.2', '0.0.1', '0.1.2', '1.0.0', '3.0.2', '7.10', '6.1.0', '2.1.0', '1.4.0']
     classes = ['', '::Config', '::Service', '::Server', '::Client', '::Packages']
-    dropsonde_cache = Dropsonde::Cache.new()
     [
-      modules: dropsonde_cache.modules
+      modules: Dropsonde::Cache.modules
                               .sample(rand(100))
                               .map do |item|
                  {
@@ -130,7 +129,7 @@ class Dropsonde::Metrics::Modules
                    version: versions.sample,
                  }
                end,
-      classes: dropsonde_cache.modules
+      classes: Dropsonde::Cache.modules
                               .sample(rand(500))
                               .map do |item|
                  {

--- a/lib/dropsonde/metrics/platforms.rb
+++ b/lib/dropsonde/metrics/platforms.rb
@@ -100,7 +100,7 @@ class Dropsonde::Metrics::Platforms
     platforms = %w[RedHat Debian Windows Suse FreeBSD Darwin Archlinux AIX]
     classes   = ['', '::Config', '::Service', '::Server', '::Client', '::Packages']
 
-    dropsonde_cache = Dropsonde::Cache.new('foo', 7, true)
+    dropsonde_cache = Dropsonde::Cache.new()
     data = dropsonde_cache.modules
                           .sample(rand(35))
                           .map { |item|

--- a/lib/dropsonde/metrics/platforms.rb
+++ b/lib/dropsonde/metrics/platforms.rb
@@ -100,8 +100,7 @@ class Dropsonde::Metrics::Platforms
     platforms = %w[RedHat Debian Windows Suse FreeBSD Darwin Archlinux AIX]
     classes   = ['', '::Config', '::Service', '::Server', '::Client', '::Packages']
 
-    dropsonde_cache = Dropsonde::Cache.new()
-    data = dropsonde_cache.modules
+    data = Dropsonde::Cache.modules
                           .sample(rand(35))
                           .map { |item|
       name = item.split('-').last.capitalize + classes.sample


### PR DESCRIPTION
Several of the examples created a second cache instance. This just makes
that unnecessary.
