### PR TITLE
Update forge dependency

### DIFF
--- a/dropsonde.gemspec
+++ b/dropsonde.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency      "httpclient"
   s.add_dependency      "little-plugger"
   s.add_dependency      "puppet"
-  s.add_dependency      "puppet_forge"
+  s.add_dependency      "puppet_forge",      "~> 3"
   s.add_dependency      "semantic_puppet"
   s.add_dependency      "inifile"
   s.add_dependency      "puppetdb-ruby"


### PR DESCRIPTION
[This pull request](https://github.com/puppetlabs/forge-ruby/pull/99)
dropped support for Ruby 2.5, which still ships with some Puppet
versions. Let's pin to the previous version so that Dropsonde still
operates on older Puppet versions for now. We'll update this once
community adoption of Puppet 7+ catches up.
