### PR TITLE
Remove usage of the legacy `osfamily` fact

### DIFF
--- a/lib/dropsonde/metrics/platforms.rb
+++ b/lib/dropsonde/metrics/platforms.rb
@@ -57,7 +57,7 @@ class Dropsonde::Metrics::Platforms
     return unless puppetdb_session
 
     classes = puppetdb_session.puppet_db.request('', 'resources[certname, title] { type = "Class" }').data
-    facts   = puppetdb_session.puppet_db.request('', 'facts[certname, value] { name = "osfamily" }').data
+    facts   = puppetdb_session.puppet_db.request('', 'inventory[certname, facts.os.family] {}').data
 
     # All public Forge modules that are installed.
     modules = Puppet.lookup(:environments).list.map { |env|
@@ -73,7 +73,7 @@ class Dropsonde::Metrics::Platforms
 
       item['platform'] = facts.find { |fact|
         fact['certname'] == item['certname']
-      }['value']
+      }['facts.os.family']
 
       {
         name: item['title'],

--- a/spec/support/examples/platforms.rb
+++ b/spec/support/examples/platforms.rb
@@ -34,15 +34,15 @@ RSpec.shared_examples 'platforms_spec' do |plugin, plugin_name|
         },
       ],
     )
-    allow(puppet_db).to receive(:request).with('', 'facts[certname, value] { name = "osfamily" }').and_return(facts)
+    allow(puppet_db).to receive(:request).with('', 'inventory[certname, facts.os.family] {}').and_return(facts)
     allow(facts).to receive(:data).and_return(
       [
         {
-          'value' => 'linux',
+          'facts.os.family' => 'linux',
           'certname' => 'aaa',
         },
         {
-          'value' => 'windows',
+          'facts.os.family' => 'windows',
           'certname' => 'bbb',
         },
       ],


### PR DESCRIPTION
Puppet 8 does not provide legacy facts anymore, so the query return an
empty list.  Replace the query with one that get the value of the
structured fact `os.family` instead.

This fix run when legacy facts are not being used.
